### PR TITLE
Fix shuffleSRVs: Use builtin shuffle

### DIFF
--- a/tmplfuncs/template_funcs.go
+++ b/tmplfuncs/template_funcs.go
@@ -127,11 +127,7 @@ func shuffleSRVs(seed int64, ary []*dns.SRV) []*dns.SRV {
 
 	src := rand.NewSource(seed)
 	rnd := rand.New(src)
-
-	for i := n - 1; i >= 0; i-- {
-		j := rnd.Intn(i + 1)
-		newAry[i], newAry[j] = newAry[j], newAry[i]
-	}
+	rnd.Shuffle(n, func(i, j int) { newAry[i], newAry[j] = newAry[j], newAry[i] })
 
 	return newAry
 }

--- a/tmplfuncs/template_funcs_test.go
+++ b/tmplfuncs/template_funcs_test.go
@@ -119,10 +119,10 @@ func TestTemplateFuncShuffleSRVs(t *testing.T) {
 
 	actual := shuffleSRVs(3, ary)
 	assert.Equal(5, len(actual))
-	assert.Equal(actual[0].Target, "5")
-	assert.Equal(actual[1].Target, "3")
-	assert.Equal(actual[2].Target, "1")
-	assert.Equal(actual[3].Target, "2")
+	assert.Equal(actual[0].Target, "1")
+	assert.Equal(actual[1].Target, "2")
+	assert.Equal(actual[2].Target, "5")
+	assert.Equal(actual[3].Target, "3")
 	assert.Equal(actual[4].Target, "4")
 }
 

--- a/tmplfuncs/template_funcs_test.go
+++ b/tmplfuncs/template_funcs_test.go
@@ -94,6 +94,12 @@ func TestTemplateFuncsRotateSRVs(t *testing.T) {
 	assert.Equal(actual[2].Target, "1")
 	assert.Equal(actual[3].Target, "2")
 	assert.Equal(actual[4].Target, "3")
+
+	assert.Equal(ary[0].Target, "1")
+	assert.Equal(ary[1].Target, "2")
+	assert.Equal(ary[2].Target, "3")
+	assert.Equal(ary[3].Target, "4")
+	assert.Equal(ary[4].Target, "5")
 }
 
 func TestTemplateFuncsFetchSRVs(t *testing.T) {
@@ -117,13 +123,27 @@ func TestTemplateFuncShuffleSRVs(t *testing.T) {
 		&dns.SRV{Target: "5"},
 	}
 
-	actual := shuffleSRVs(3, ary)
-	assert.Equal(5, len(actual))
-	assert.Equal(actual[0].Target, "1")
-	assert.Equal(actual[1].Target, "2")
-	assert.Equal(actual[2].Target, "5")
-	assert.Equal(actual[3].Target, "3")
-	assert.Equal(actual[4].Target, "4")
+	actual1 := shuffleSRVs(3, ary)
+	assert.Equal(5, len(actual1))
+	assert.Equal(actual1[0].Target, "1")
+	assert.Equal(actual1[1].Target, "2")
+	assert.Equal(actual1[2].Target, "5")
+	assert.Equal(actual1[3].Target, "3")
+	assert.Equal(actual1[4].Target, "4")
+
+	actual2 := shuffleSRVs(4, ary)
+	assert.Equal(5, len(actual2))
+	assert.Equal(actual2[0].Target, "4")
+	assert.Equal(actual2[1].Target, "3")
+	assert.Equal(actual2[2].Target, "5")
+	assert.Equal(actual2[3].Target, "1")
+	assert.Equal(actual2[4].Target, "2")
+
+	assert.Equal(ary[0].Target, "1")
+	assert.Equal(ary[1].Target, "2")
+	assert.Equal(ary[2].Target, "3")
+	assert.Equal(ary[3].Target, "4")
+	assert.Equal(ary[4].Target, "5")
 }
 
 func TestTemplateHexToI(t *testing.T) {


### PR DESCRIPTION
Fix shufflesrvs template function.
Use Golang builtin shuffle function:
https://golang.org/pkg/math/rand/#Rand.Shuffle
